### PR TITLE
Use Prism for server-side changelog syntax highlighting

### DIFF
--- a/build.js
+++ b/build.js
@@ -25,10 +25,20 @@ const LANGUAGE_ALIASES = {
 
 loadLanguages([FALLBACK_LANGUAGE]);
 
-marked.setOptions({
-  langPrefix: 'language-',
-  highlight(code, lang) {
-    return highlightCodeBlock(code, lang);
+const renderer = new marked.Renderer();
+
+renderer.code = function renderCode(code, infostring, escaped) {
+  const language = normalizeLanguage(infostring);
+  const highlighted = highlightCodeBlock(code, language);
+  const className = `language-${language || FALLBACK_LANGUAGE}`;
+
+  return `<pre class="${className}"><code class="${className}">${highlighted}\n</code></pre>\n`;
+};
+
+marked.use({
+  renderer,
+  options: {
+    langPrefix: 'language-'
   }
 });
 
@@ -133,7 +143,7 @@ function normalizeLanguage(language) {
     return FALLBACK_LANGUAGE;
   }
 
-  const lower = language.toLowerCase();
+  const lower = language.toLowerCase().replace(/^language-/, '');
   return LANGUAGE_ALIASES[lower] || lower;
 }
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "cheerio": "1.0.0-rc.12",
     "marked": "9.1.6",
     "@mongoosejs/studio": "0.0.124",
+    "prismjs": "1.29.0",
     "tailwindcss": "3.x"
   },
   "devDependencies": {

--- a/public/prism-theme.css
+++ b/public/prism-theme.css
@@ -1,15 +1,8 @@
-html {
-  --prism-background: #1f2937;
-  --prism-border: rgba(15, 23, 42, 0.08);
+:root {
+  --prism-background: #f8fafc;
+  --prism-border: #e2e8f0;
   --prism-foreground: #0f172a;
-  --prism-inline-background: rgba(15, 23, 42, 0.08);
-}
-
-html.dark {
-  --prism-background: #0f172a;
-  --prism-border: rgba(148, 163, 184, 0.18);
-  --prism-foreground: #e2e8f0;
-  --prism-inline-background: rgba(148, 163, 184, 0.12);
+  --prism-inline-background: #e2e8f0;
 }
 
 code[class*='language-'],
@@ -18,13 +11,13 @@ pre[class*='language-'] {
   background: transparent;
   font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', Menlo, Monaco, Consolas,
     'Liberation Mono', 'Courier New', monospace;
-  font-size: 0.875rem;
+  font-size: 0.9rem;
   text-shadow: none;
   direction: ltr;
   text-align: left;
   word-spacing: normal;
   word-break: normal;
-  line-height: 1.65;
+  line-height: 1.6;
   tab-size: 2;
   hyphens: none;
 }
@@ -39,8 +32,8 @@ pre[class*='language-'] {
 }
 
 :not(pre) > code[class*='language-'] {
-  padding: 0.25rem 0.5rem;
-  border-radius: 0.5rem;
+  padding: 0.15rem 0.35rem;
+  border-radius: 0.35rem;
   background-color: var(--prism-inline-background);
   white-space: normal;
 }
@@ -54,7 +47,7 @@ pre[class*='language-'] {
 }
 
 .token.punctuation {
-  color: #cbd5f5;
+  color: #64748b;
 }
 
 .token.property,
@@ -62,12 +55,12 @@ pre[class*='language-'] {
 .token.constant,
 .token.symbol,
 .token.deleted {
-  color: #f87171;
+  color: #dc2626;
 }
 
 .token.boolean,
 .token.number {
-  color: #fbbf24;
+  color: #b45309;
 }
 
 .token.selector,
@@ -76,7 +69,7 @@ pre[class*='language-'] {
 .token.char,
 .token.builtin,
 .token.inserted {
-  color: #34d399;
+  color: #15803d;
 }
 
 .token.operator,
@@ -85,23 +78,23 @@ pre[class*='language-'] {
 .language-css .token.string,
 .style .token.string,
 .token.variable {
-  color: #f472b6;
+  color: #7c3aed;
 }
 
 .token.atrule,
 .token.attr-value,
 .token.keyword {
-  color: #60a5fa;
+  color: #1d4ed8;
 }
 
 .token.function,
 .token.class-name {
-  color: #c4b5fd;
+  color: #c026d3;
 }
 
 .token.regex,
 .token.important {
-  color: #facc15;
+  color: #b91c1c;
 }
 
 .token.bold,
@@ -126,10 +119,6 @@ pre[class*='language-']::-webkit-scrollbar-track {
 }
 
 pre[class*='language-']::-webkit-scrollbar-thumb {
-  background: rgba(148, 163, 184, 0.4);
+  background: rgba(148, 163, 184, 0.6);
   border-radius: 999px;
-}
-
-html.dark pre[class*='language-']::-webkit-scrollbar-thumb {
-  background: rgba(148, 163, 184, 0.25);
 }

--- a/public/prism-theme.css
+++ b/public/prism-theme.css
@@ -1,0 +1,135 @@
+html {
+  --prism-background: #1f2937;
+  --prism-border: rgba(15, 23, 42, 0.08);
+  --prism-foreground: #0f172a;
+  --prism-inline-background: rgba(15, 23, 42, 0.08);
+}
+
+html.dark {
+  --prism-background: #0f172a;
+  --prism-border: rgba(148, 163, 184, 0.18);
+  --prism-foreground: #e2e8f0;
+  --prism-inline-background: rgba(148, 163, 184, 0.12);
+}
+
+code[class*='language-'],
+pre[class*='language-'] {
+  color: var(--prism-foreground);
+  background: transparent;
+  font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', Menlo, Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.875rem;
+  text-shadow: none;
+  direction: ltr;
+  text-align: left;
+  word-spacing: normal;
+  word-break: normal;
+  line-height: 1.65;
+  tab-size: 2;
+  hyphens: none;
+}
+
+pre[class*='language-'] {
+  padding: 1.25rem 1.5rem;
+  margin: 0;
+  overflow: auto;
+  border-radius: 0.75rem;
+  background-color: var(--prism-background);
+  box-shadow: inset 0 0 0 1px var(--prism-border);
+}
+
+:not(pre) > code[class*='language-'] {
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.5rem;
+  background-color: var(--prism-inline-background);
+  white-space: normal;
+}
+
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+  color: #94a3b8;
+  font-style: italic;
+}
+
+.token.punctuation {
+  color: #cbd5f5;
+}
+
+.token.property,
+.token.tag,
+.token.constant,
+.token.symbol,
+.token.deleted {
+  color: #f87171;
+}
+
+.token.boolean,
+.token.number {
+  color: #fbbf24;
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+  color: #34d399;
+}
+
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string,
+.token.variable {
+  color: #f472b6;
+}
+
+.token.atrule,
+.token.attr-value,
+.token.keyword {
+  color: #60a5fa;
+}
+
+.token.function,
+.token.class-name {
+  color: #c4b5fd;
+}
+
+.token.regex,
+.token.important {
+  color: #facc15;
+}
+
+.token.bold,
+.token.important {
+  font-weight: 600;
+}
+
+.token.italic {
+  font-style: italic;
+}
+
+.token.entity {
+  cursor: help;
+}
+
+pre[class*='language-']::-webkit-scrollbar {
+  height: 0.6rem;
+}
+
+pre[class*='language-']::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+pre[class*='language-']::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.4);
+  border-radius: 999px;
+}
+
+html.dark pre[class*='language-']::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.25);
+}

--- a/src/layout.html
+++ b/src/layout.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title></title>
     <link rel="stylesheet" href="/tw.css" />
+    <link rel="stylesheet" href="/prism-theme.css" />
     <script src="https://cdn.jsdelivr.net/npm/@tailwindplus/elements@1" type="module"></script>
     <style>
       body {
@@ -25,6 +26,11 @@
       }
       main li + li {
         margin-top: 0.5rem;
+      }
+      main pre {
+        margin-top: 1.5rem;
+        overflow-x: auto;
+        border-radius: 0.75rem;
       }
     </style>
   </head>


### PR DESCRIPTION
## Summary
- add Prism as a dependency and configure the changelog builder to use it for server-side code highlighting
- replace CDN assets with a locally served Prism theme stylesheet for changelog pages

## Testing
- `npm run build` *(fails: dependencies such as cheerio/prismjs cannot be installed in this environment due to restricted registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68e4395fdb608324a123446e787f8cfe