### PR TITLE
Add open-source callout and GitHub star button to homepage

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -148,39 +148,6 @@
               <span class="inline-flex items-center gap-2"><span class="text-green-700">✓</span>Deployed via Express middleware or Vercel</span>
             </div>
           </div>
-          <section class="mx-auto mt-10 max-w-5xl rounded-3xl border border-gray-200 bg-white p-8 text-left shadow-lg sm:p-10">
-            <div class="flex flex-wrap items-center justify-between gap-4">
-              <h2 class="text-2xl font-semibold tracking-tight text-gray-900 sm:text-3xl">Free. Open source. Yours.</h2>
-              <iframe
-                src="https://ghbtns.com/github-btn.html?user=mongoosejs&repo=studio&type=star&count=true&size=large"
-                title="Star mongoosejs/studio on GitHub"
-                width="170"
-                height="30"
-                class="overflow-hidden rounded border border-gray-200"
-                loading="lazy"
-              ></iframe>
-            </div>
-            <p class="mt-4 text-base leading-7 text-gray-700 sm:text-lg">
-              Run Mongoose Studio locally, inside your app, with zero accounts and zero setup.
-            </p>
-            <p class="mt-3 text-base leading-7 text-gray-700 sm:text-lg">
-              Explore your data, build dashboards, and use AI-powered queries — all without sending your data anywhere.
-            </p>
-            <p class="mt-3 text-base leading-7 text-gray-700 sm:text-lg">
-              Bring your own API key for OpenAI, Anthropic, or Google Gemini and stay fully in control.
-            </p>
-            <p class="mt-3 text-base leading-7 text-gray-700 sm:text-lg">
-              No lock-in. No hosted dependency. No surprises.
-            </p>
-            <a
-              href="https://github.com/mongoosejs/studio"
-              target="_blank"
-              rel="noreferrer"
-              class="mt-6 inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-900 hover:bg-gray-50"
-            >
-              View the GitHub repo
-            </a>
-          </section>
           <div class="mx-auto mt-10 max-w-7xl">
             <div class="relative rounded-3xl border border-gray-200 bg-white p-2 shadow-2xl sm:p-3 lg:p-3">
               <div class="absolute inset-x-8 top-0 h-px bg-gradient-to-r from-transparent via-white to-transparent"></div>
@@ -1021,6 +988,44 @@
             <h3 class="mt-4 text-2xl font-semibold text-gray-900">GeoJSON</h3>
             <p class="mt-3 text-base text-gray-600">View GeoJSON data on a map and edit via drag and drop.</p>
           </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="bg-white py-20 sm:py-24 border-t border-gray-100">
+      <div class="mx-auto max-w-7xl px-6 lg:px-8">
+        <div class="mx-auto max-w-5xl rounded-3xl border border-gray-200 bg-white p-8 text-left shadow-lg sm:p-10">
+          <div class="flex flex-wrap items-center justify-between gap-4">
+            <h2 class="text-3xl font-semibold tracking-tight text-gray-900 sm:text-4xl">Free. Open source. Yours.</h2>
+            <a href="https://github.com/mongoosejs/studio/stargazers" target="_blank" rel="noreferrer" class="inline-flex items-center">
+              <img
+                src="https://img.shields.io/github/stars/mongoosejs/studio?style=social&label=Star"
+                alt="Star count for mongoosejs/studio on GitHub"
+                class="h-8 w-auto"
+                loading="lazy"
+              >
+            </a>
+          </div>
+          <p class="mt-4 text-base leading-7 text-gray-700 sm:text-lg">
+            Run Mongoose Studio locally, inside your app, with zero accounts and zero setup.
+          </p>
+          <p class="mt-3 text-base leading-7 text-gray-700 sm:text-lg">
+            Explore your data, build dashboards, and use AI-powered queries — all without sending your data anywhere.
+          </p>
+          <p class="mt-3 text-base leading-7 text-gray-700 sm:text-lg">
+            Bring your own API key for OpenAI, Anthropic, or Google Gemini and stay fully in control.
+          </p>
+          <p class="mt-3 text-base leading-7 text-gray-700 sm:text-lg">
+            No lock-in. No hosted dependency. No surprises.
+          </p>
+          <a
+            href="https://github.com/mongoosejs/studio"
+            target="_blank"
+            rel="noreferrer"
+            class="mt-6 inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-900 hover:bg-gray-50"
+          >
+            View the GitHub repo
+          </a>
         </div>
       </div>
     </section>

--- a/public/index.html
+++ b/public/index.html
@@ -148,6 +148,39 @@
               <span class="inline-flex items-center gap-2"><span class="text-green-700">✓</span>Deployed via Express middleware or Vercel</span>
             </div>
           </div>
+          <section class="mx-auto mt-10 max-w-5xl rounded-3xl border border-gray-200 bg-white p-8 text-left shadow-lg sm:p-10">
+            <div class="flex flex-wrap items-center justify-between gap-4">
+              <h2 class="text-2xl font-semibold tracking-tight text-gray-900 sm:text-3xl">Free. Open source. Yours.</h2>
+              <iframe
+                src="https://ghbtns.com/github-btn.html?user=mongoosejs&repo=studio&type=star&count=true&size=large"
+                title="Star mongoosejs/studio on GitHub"
+                width="170"
+                height="30"
+                class="overflow-hidden rounded border border-gray-200"
+                loading="lazy"
+              ></iframe>
+            </div>
+            <p class="mt-4 text-base leading-7 text-gray-700 sm:text-lg">
+              Run Mongoose Studio locally, inside your app, with zero accounts and zero setup.
+            </p>
+            <p class="mt-3 text-base leading-7 text-gray-700 sm:text-lg">
+              Explore your data, build dashboards, and use AI-powered queries — all without sending your data anywhere.
+            </p>
+            <p class="mt-3 text-base leading-7 text-gray-700 sm:text-lg">
+              Bring your own API key for OpenAI, Anthropic, or Google Gemini and stay fully in control.
+            </p>
+            <p class="mt-3 text-base leading-7 text-gray-700 sm:text-lg">
+              No lock-in. No hosted dependency. No surprises.
+            </p>
+            <a
+              href="https://github.com/mongoosejs/studio"
+              target="_blank"
+              rel="noreferrer"
+              class="mt-6 inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-900 hover:bg-gray-50"
+            >
+              View the GitHub repo
+            </a>
+          </section>
           <div class="mx-auto mt-10 max-w-7xl">
             <div class="relative rounded-3xl border border-gray-200 bg-white p-2 shadow-2xl sm:p-3 lg:p-3">
               <div class="absolute inset-x-8 top-0 h-px bg-gradient-to-r from-transparent via-white to-transparent"></div>


### PR DESCRIPTION
### Motivation
- Surface the project’s open-source, local-first positioning prominently on the homepage to match marketing copy requirements.
- Provide a one-click way for visitors to star the repository and a direct link to the GitHub repo to increase discoverability and contribution.

### Description
- Added a new callout section to `public/index.html` containing the requested headline and paragraphs starting with “Free. Open source. Yours.”.
- Embedded a clickable GitHub star button with live star count via the GitHub buttons iframe (`https://ghbtns.com/github-btn.html?user=mongoosejs&repo=studio&type=star&count=true&size=large`).
- Added a “View the GitHub repo” CTA linking to `https://github.com/mongoosejs/studio` and applied consistent Tailwind styling to match the page.

### Testing
- Ran `npm test`; the test run produced 2 passing tests and 1 failing test in `test/track.test.js` (`uses a dedicated createConnection and caches it across requests`).
- The failing test is unrelated to this HTML-only change and appears to be a pre-existing issue in `api/track` behavior observed during the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7fbbb96308324968685549a5ff579)