### PR TITLE
Improve hero feature badge readability on mobile

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -107,7 +107,7 @@
           <div class="mx-auto max-w-4xl text-center">
             <span class="inline-flex max-w-full flex-wrap items-center justify-center gap-2 rounded-2xl border border-gray-200 bg-white px-3 py-3 text-sm font-semibold text-gray-700 sm:rounded-full sm:px-4 sm:py-2">
                 <span class="rounded-full bg-gray-100 px-2 py-0.5 text-gray-900">New</span>
-                <span class="text-gray-900">AI Query Assistant</span>
+                <span class="text-gray-700">AI Query Assistant</span>
                 <span class="hidden text-gray-400 sm:inline">·</span>
                 <span class="rounded-full bg-slate-50 px-2 py-0.5 text-gray-700 sm:bg-transparent sm:px-0 sm:py-0">Dashboards</span>
                 <span class="hidden text-gray-400 sm:inline">·</span>

--- a/public/index.html
+++ b/public/index.html
@@ -105,13 +105,13 @@
         </div>
         <div class="mx-auto max-w-7xl py-20 sm:py-14 lg:py-20">
           <div class="mx-auto max-w-4xl text-center">
-            <span class="inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white px-4 py-2 text-sm font-semibold text-gray-700">
+            <span class="inline-flex max-w-full flex-wrap items-center justify-center gap-2 rounded-2xl border border-gray-200 bg-white px-3 py-3 text-sm font-semibold text-gray-700 sm:rounded-full sm:px-4 sm:py-2">
                 <span class="rounded-full bg-gray-100 px-2 py-0.5 text-gray-900">New</span>
-                AI Query Assistant
-                <span class="text-gray-400">·</span>
-                Dashboards
-                <span class="text-gray-400">·</span>
-                Team Access
+                <span class="text-gray-900">AI Query Assistant</span>
+                <span class="hidden text-gray-400 sm:inline">·</span>
+                <span class="rounded-full bg-slate-50 px-2 py-0.5 text-gray-700 sm:bg-transparent sm:px-0 sm:py-0">Dashboards</span>
+                <span class="hidden text-gray-400 sm:inline">·</span>
+                <span class="rounded-full bg-slate-50 px-2 py-0.5 text-gray-700 sm:bg-transparent sm:px-0 sm:py-0">Team Access</span>
             </span>
             <h1 class="mt-5 text-5xl font-semibold tracking-tight text-gray-900 sm:text-6xl lg:text-7xl">A Developer-First MongoDB GUI</h1>
             <p class="mt-5 text-xl leading-tight text-gray-700 sm:text-3xl sm:leading-tight">Browser-based, model-aware, and AI-assisted MongoDB interface for building and managing applications.</p>


### PR DESCRIPTION
### Motivation
- Fix the homepage hero feature badge so the multi-line `AI Query Assistant · Dashboards · Team Access` group renders cleanly and remains readable on small screens.

### Description
- Tweak `public/index.html` to use a wrapping, max-width-aware inline-flex container with adjusted padding and rounded corners for mobile, hide dot separators on small screens, and render secondary items as chip-like spans while preserving desktop behavior.

### Testing
- Ran `npm test`, which returned 2 passing and 1 failing test; the failing test is `api/track` - "uses a dedicated createConnection and caches it across requests" and is unrelated to this HTML/CSS change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d810aacab08324ab40ed2907b47285)